### PR TITLE
Sandbox the generated template functions within the VM sandbox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,16 @@ Options can be set via `soynode.setOptions(options)`, the keys can contain the f
 
 **NOTE: Options should be set before templates are loaded or compiled.**
 
-Caveats
--------
+Implementation Notes
+--------------------
 
-The present implementation loads the compiled templates in the global scope.  So while it is
-recommended that you access templates via `soynode.get(project.section.content)` you could reference
-the symbol `project.section.content()` directly.  This does mean there is a chance that template
-namespaces will collide with other variables.
+The templates are loaded using Node's [VM Module](http://nodejs.org/api/vm.html).  This allows us to
+execute the generated `.soy.js` files as is without a post processing step and without leaking the
+template functions into the global scope.
 
-I would have preferred to execute the templates using `vm.runInContext()` however the additional
-overhead meant runtime was several orders of magnitude slower than direct function calls.
-
-In the future it would be nice to sandbox the template functions, so you should not rely on the
-presence of the templates as global symbols.
+Calling `soynode.get` executes code which returns a reference to the template function within the
+VM Context.  The reference is cached, providing a 10x speed up over fetching the template function
+each time, or evaluating it in place and returning the template output over the VM boundary.
 
 Contributing
 ------------

--- a/examples/benchmark.js
+++ b/examples/benchmark.js
@@ -1,0 +1,33 @@
+// Copyright (c)2012 The Obvious Corporation
+
+/**
+ * @fileoverview Basic benchmark for hello world template that calls one nested template.
+ */
+
+var soynode = require('../lib/soynode')
+
+var USER = process.env.USER || 'Stranger'
+
+soynode.setOptions({
+    tmpDir: '/tmp/soynode-example'
+  , eraseTemporaryFiles: true
+})
+
+var iterations = 5000
+
+soynode.compileTemplates(__dirname, function (err) {
+  if (err) throw err
+  var d = Date.now()
+  var results = []
+  for (var i = 0; i < iterations; i++) {
+    results.push(soynode.render('example.message.hello', {
+        name: USER
+      , date: new Date().toLocaleTimeString()
+    }))
+  }
+  var diff = Date.now() - d
+
+  console.log('Total time spent:', diff, 'ms')
+  console.log('Number of iterations:', iterations)
+  console.log('Ops per sec:', Math.round((1000 / diff) * iterations))
+})

--- a/lib/soynode.js
+++ b/lib/soynode.js
@@ -31,12 +31,18 @@ var PATH_TO_SOY = path.join(__dirname, '..', 'soy', 'SoyToJsSrcCompiler.jar')
 
 /**
  * VM Context that is used as the global when fetching templates.  The end result is that this
- * object contains references to the JS functions rendered by Soy.  It will be mixed into the global
- * object for fast access to the template functions, since executing templates over the VM
- * boundary appears to be rather slow.
+ * object contains references to the JS functions rendered by Soy.
  * @type {Object}
  */
 var vmContext = vm.createContext({})
+
+
+/**
+ * A cache for function pointers returned by the vm.runInContext call.  Caching the reference
+ * results in a 10x speed improvement, over calling getting the function each time.
+ * @type {Object}
+ */
+var templateCache = {}
 
 
 /**
@@ -95,13 +101,16 @@ function setOptions(opts) {
  * @return {function (Object) : string}
  */
 function get(templateName) {
-  var parts = templateName.split('.')
-  var template = global
-  while (parts.length && template) {
-    template = template[parts.shift()]
+  if (!templateCache[templateName]) {
+    var template
+    try {
+      template = vm.runInContext(templateName, vmContext, 'soynode.vm')
+    } catch (e) {}
+
+    if (!template) throw new Error('soynode: Unknown template [' + templateName + ']')
+    templateCache[templateName] = template
   }
-  if (!template) throw new Error('soynode: Unknown template [' + templateName + ']')
-  return template
+  return templateCache[templateName]
 }
 
 
@@ -202,20 +211,18 @@ function loadCompiledTemplates(inputDir, callback) {
  * @param {function (Error, boolean)} callback
  */
 function loadCompiledTemplateFiles(files, callback) {
+  // Blow away the cache.
+  templateCache = {}
+
   function next() {
     if (files.length === 0) {
-      // When all files have been processed, mix in references to the vmContext onto the global
-      // object.  This can be called multiple times and will just override references.  This is
-      // slightly unfortunate but is necessary for performance reasons, see the "Caveat" section in
-      // the README file.
-      mixinGlobal(vmContext)
       callback(null, true)
     } else {
       var path = files.pop()
       fs.readFile(path, 'utf8', function (err, fileContents) {
         if (err) return callback(err, false)
         // Evaluate the template code in the context of the soy VM context.  Any variables defined
-        // in the template file will become members of the templates object.
+        // in the template file will become members of the vmContext object.
         vm.runInContext(fileContents, vmContext, path)
         next()
       })
@@ -298,15 +305,4 @@ function watchFiles(files, fn) {
 function logErrorOrDone(err, res) {
   if (err) console.error('soynode:', err)
   else console.log('soynode: Done')
-}
-
-
-/**
- * Mixes all keys from the context into the global scope.
- * @param {Object} context
- */
-function mixinGlobal(context) {
-  for (var key in context) {
-    global[key] = context[key]
-  }
 }


### PR DESCRIPTION
By returning a function reference from `vm.runInContext` we can
execute the template functions in place without having to mix them
into the global scope.
