### PR TITLE
Add concatOutput option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Options can be set via `soynode.setOptions(options)`, the keys can contain the f
 - `allowDynamicRecompile` {boolean} Whether to watch for changes to the templates. [Default: false]
 - `eraseTemporaryFiles` {boolean} Whether to erase temporary files after a compilation.
 [Default: false]
+- `concatOutput` {boolean} Whether the compiled soy.js files should be joined into a single file. This is helpful for loading templates in a browser and simplest to use when `outputDir` is explicitly set and `uniqueDir` is false. [Default: false]
+- `concatFileName` {string} File name used for concatenated files, only relevant when concatOutput is true, ".soy.concat.js" is appended, so don't include ".js" yourself. [Default: compiled]
 
 **NOTE: Options should be set before templates are loaded or compiled.**
 

--- a/lib/soynode.js
+++ b/lib/soynode.js
@@ -92,8 +92,13 @@ var options = {
     // Additional JS files to be evaluated in the VM context for the soy templates.  
 	// Useful for soy function support libs
   , contextJsPaths: [ ]
-}
 
+    // Whether the compiled soy.js files should be joined into a single file
+  , concatOutput: false
+
+    // File name used for concatenated files, only relevant when concatOutput is true.
+  , concatFileName: 'compiled'
+}
 
 /**
  * Sets options which affect how soynode operates.
@@ -114,6 +119,13 @@ function setOptions(opts) {
     if (key == 'tmpDir') options['tmpDir'] = path.resolve(opts['tmpDir'])
     else if (key == 'outputDir') options['outputDir'] = path.resolve(opts['outputDir'])
     else options[key] = opts[key]
+  }
+
+  //Determine where the compiled soy will be placed. tmpDir is allowed for backwards compatibility.
+  options._realOutputDirectory = options.outputDir || options.tmpDir
+  if (options.uniqueDir !== false) {
+    var timeDirectory = new Date().toISOString().replace(/\:/g, '_')
+    options._realOutputDirectory = path.join(options._realOutputDirectory, timeDirectory)
   }
 }
 
@@ -192,19 +204,13 @@ function compileTemplatesAndEmit(inputDir, emitter) {
       watchFiles(filePaths, compileTemplatesAndEmit.bind(null, inputDir, emitter))
     }
 
-    //Determine where the compiled soy will be placed. tmpDir is allowed for backwards compatibility.
-    var outputDirectory = options.outputDir || options.tmpDir;
-    if (options.uniqueDir !== false) {
-      outputDirectory = path.join(outputDirectory, new Date().toISOString().replace(/\:/g, '_'))
-    }
-
     // Arguments for running the soy compiler via java.
     var args = [
         '-classpath', [ PATH_TO_SOY_JAR ].concat(options.classpath).join(path.delimiter)
       , 'com.google.template.soy.SoyToJsSrcCompiler'
       , '--codeStyle', 'concat'
       , '--shouldGenerateJsdoc'
-      , '--outputPathFormat', outputDirectory + '/{INPUT_DIRECTORY}{INPUT_FILE_NAME}.js'
+      , '--outputPathFormat', options._realOutputDirectory + '/{INPUT_DIRECTORY}{INPUT_FILE_NAME}.js'
     ]
     if (options.useClosureStyle) {
       args.push('--shouldProvideRequireSoyNamespaces')
@@ -231,15 +237,22 @@ function compileTemplatesAndEmit(inputDir, emitter) {
 
         // Build a list of paths that we expect as output of the soy compiler.
         var templatePaths = files.map(function (file) {
-          return path.join(outputDirectory , file) + '.js'
+          return path.join(options._realOutputDirectory , file) + '.js'
         })
+
+        try {
+          if (options.concatOutput) concatOutput(templatePaths)
+        } catch (e) {
+          console.warn('soynode: Error concatenating files', e)
+        }
 
         // Load the compiled templates into memory.
         loadCompiledTemplateFiles(templatePaths, function (err) {
           if (err) return emitter.emit('compile', err, false)
+
           emitter.emit('compile', null, true)
           if (options.eraseTemporaryFiles) {
-            exec('rm -r \'' + outputDirectory + '\'', {}, function (err, stdout, stderr) {
+            exec('rm -r \'' + options._realOutputDirectory + '\'', {}, function (err, stdout, stderr) {
               // TODO(dan): This is a pretty nasty way to delete the files.  Maybe use rimraf
               if (err) console.error('soynode: Error deleting temporary files', err)
             })
@@ -364,6 +377,19 @@ function watchFiles(files, fn) {
      console.warn('soynode: Error watching ' + file, e)
     }
   })
+}
+
+ /**
+ * Concatenates all output files into a single file.
+ * @param {Array.<string>} files
+ */
+function concatOutput(files) {
+  var target = path.join(options._realOutputDirectory, options.concatFileName + '.soy.concat.js')
+  var concatenated = files.map(function (file) {
+    return fs.readFileSync(file).toString()
+  }).join('')
+
+  fs.writeFileSync(target, concatenated)
 }
 
 


### PR DESCRIPTION
Hello @dpup, 

Please review the following commits I made in branch 'es-concat-output-option'.

86395b877581697633aba190c87ea57c7969a249 (2014-01-30 20:13:19 -0800)
Add concatOutput option
Allows generated JS to be concatenated into a single file, which is helpful for using templates on the front end

R=@dpup
