### PR TITLE
Fix a bug where compileTemplateFilesAndEmit inputDir parameter was not bound.

### DIFF
--- a/lib/soynode.js
+++ b/lib/soynode.js
@@ -254,7 +254,7 @@ function compileTemplateFilesAndEmit(inputDir, files, emitter) {
     // Set up a watch for changes to files.  Currently this will recompile all templates when
     // ever one changes. TODO(dan): Make this compile individual files.
     var filePaths = files.map(function (file) { return path.resolve(inputDir, file) })
-    watchFiles(filePaths, compileTemplateFilesAndEmit.bind(null, files, emitter))
+    watchFiles(filePaths, compileTemplateFilesAndEmit.bind(null, inputDir, files, emitter))
   }
 
   // Arguments for running the soy compiler via java.


### PR DESCRIPTION
Fix a bug where compileTemplateFilesAndEmit inputDir parameter was not bound properly when doing a dynamic compilation causing a TypeError.

/node_modules/soynode/lib/soynode.js:256
    var filePaths = files.map(function (file) { return path.resolve(inputDir, 
                          ^
TypeError: Object #<EventEmitter> has no method 'map'
    at compileTemplateFilesAndEmit (/node_modules/soynode/lib/soynode.js:256:27)
    at StatWatcher.<anonymous> (/node_modules/soynode/lib/soynode.js:473:9)
    at StatWatcher.EventEmitter.emit (events.js:98:17)
    at StatWatcher._handle.onchange (fs.js:1104:10)
