### PR TITLE
Handle java 'error' event

### DIFF
--- a/lib/soynode.js
+++ b/lib/soynode.js
@@ -297,7 +297,7 @@ function compileTemplateFilesAndEmit(inputDir, files, emitter) {
 
   args.push('--outputPathFormat', outputPathFormat)
 
-  // Execute the comamnd inside the input directory.
+  // Execute the command inside the input directory.
   var cp = child_process.spawn('java', args, {cwd: inputDir})
 
   var stderr = ''
@@ -305,7 +305,17 @@ function compileTemplateFilesAndEmit(inputDir, files, emitter) {
     stderr += data
   })
 
+  var cpError = false
+  cp.on('error', function (err) {
+    console.error('soynode: Failed executing the \'java\' command\n')
+    emitter.emit('compile', err, false)
+    cpError = true
+  })
+
   cp.on('exit', function (exitCode) {
+    if (cpError) {
+      return; // already fired the 'error' event
+    }
     if (exitCode != 0) {
       // Log all the errors and execute the callback with a generic error object.
       console.error('soynode: Compile error\n', stderr)


### PR DESCRIPTION
When running soynode on a system where _java_ was not yet installed, I ran into the following error:

```bash
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:1000:11)
    at Process.ChildProcess._handle.onexit (child_process.js:791:34)
```

This PR adds a handler for the 'error' event, resulting in a readable/catchable error.