### PR TITLE
1 minor change (added jarPath as option).

### DIFF
--- a/lib/SoyCompiler.js
+++ b/lib/SoyCompiler.js
@@ -6,7 +6,6 @@ var SoyVmContext = require('./SoyVmContext')
 var EventEmitter = require('events').EventEmitter
 var child_process = require('child_process')
 var exec = child_process.exec
-var closureTemplates = require('closure-templates')
 var fs = require('fs')
 var path = require('path')
 
@@ -15,13 +14,6 @@ var path = require('path')
  * The key in vmContexts for the default vm context (with no locale).
  */
 var DEFAULT_VM_CONTEXT = 'default'
-
-
-/**
- * Resolved path to the executable jar for the Closure Template compiler.
- * @type {string}
- */
-var PATH_TO_SOY_JAR = closureTemplates['SoyToJsSrcCompiler.jar']
 
 
 /**
@@ -205,7 +197,7 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
 
   // Arguments for running the soy compiler via java.
   var args = [
-    '-classpath', [ PATH_TO_SOY_JAR ].concat(options.classpath).join(path.delimiter),
+    '-classpath', [ options.jarPath ].concat(options.classpath).join(path.delimiter),
     'com.google.template.soy.SoyToJsSrcCompiler',
     '--codeStyle', 'concat',
     '--shouldGenerateJsdoc',

--- a/lib/SoyOptions.js
+++ b/lib/SoyOptions.js
@@ -1,6 +1,7 @@
 // Copyright 2014. A Medium Corporation.
 
 var path = require('path')
+var closureTemplates = require('closure-templates')
 
 /**
  * Describes the possible options set to a SoyCompiler.
@@ -128,6 +129,12 @@ function SoyOptions() {
    * @type {boolean}
    */
   this.isUsingIjData = false
+
+  /**
+   * Resolved path to the executable jar for the Closure Template compiler. Defaults to using the bundled SoyToJsSrcCompiler.jar file.
+   * @type {string}
+   */
+  this.jarPath = closureTemplates['SoyToJsSrcCompiler.jar']
 }
 
 


### PR DESCRIPTION
It would be nice to be able to set the path to the SoyToJsSrcCompiler.jar in the options, so we can make sure we use the same file both in the backend and frontend rendering of Soy files. This also allows us to have control over the version of the SoyToJsSrcCompiler.jar file.