### PR TITLE
Only recompile soy templates that have changed, which should make soy recompilation much more responsive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ for `SoyToJsSrcCompiler`. The keys can contain the following:
 - `uniqueDir` {boolean} Determines whether the compiled files will be placed in a unique directory. [Default: true]
 - `allowDynamicRecompile` {boolean} Whether to watch for changes to the templates. [Default: false]
 - `loadCompiledTemplates` {boolean} Whether or not to load the compiled templates. Relevant when you only need to build templates. [Default: true]
-- `eraseTemporaryFiles` {boolean} Whether to erase temporary files after a compilation.
+- `eraseTemporaryFiles` {boolean} Whether to erase temporary files after a compilation. This option does nothing if allowDynamicRecompile is on, because allowDynamicRecompile reuses the files.
 [Default: false]
 - `concatOutput` {boolean} Whether the compiled soy.js files should be joined into a single file. This is helpful for loading templates in a browser and simplest to use when `outputDir` is explicitly set and `uniqueDir` is false. [Default: false]
 - `concatFileName` {string} File name used for concatenated files, only relevant when concatOutput is true, ".soy.concat.js" is appended, so don't include ".js" yourself. [Default: compiled]

--- a/lib/SoyCompiler.js
+++ b/lib/SoyCompiler.js
@@ -9,6 +9,7 @@ var exec = child_process.exec
 var closureTemplates = require('closure-templates')
 var fs = require('fs')
 var path = require('path')
+var Q = require('q')
 
 
 /**
@@ -158,7 +159,9 @@ SoyCompiler.prototype.compileTemplateFiles = function (files, callback) {
   if (callback) {
     emitter.once('compile', callback)
   }
-  this._compileTemplateFilesAndEmit(this._options.inputDir, files, emitter)
+  var outputDir = this._createOutputDir()
+  this._maybeSetupDynamicRecompile(this._options.inputDir, outputDir, files, emitter)
+  this._compileTemplateFilesAndEmit(this._options.inputDir, outputDir, files, files, emitter)
   return emitter
 }
 
@@ -168,7 +171,7 @@ SoyCompiler.prototype.compileTemplateFiles = function (files, callback) {
  * @return {string}
  * @private
  */
-SoyCompiler.prototype._getOutputDir = function () {
+SoyCompiler.prototype._createOutputDir = function () {
   var options = this._options
   var dir = options.outputDir || options.tmpDir
   if (options.uniqueDir !== false) {
@@ -183,23 +186,39 @@ SoyCompiler.prototype._getOutputDir = function () {
  * Compiles all soy files, but takes an emitter to use instead of a callback.
  * @see compileTemplates for the emitter API.
  * @param {string} inputDir Input directory from where the compiler spawns.
- * @param {Array.<string>} files
+ * @param {string} outputDir
+ * @param {Array.<string>} allFiles All files, expressed relative to inputDir
+ * @param {Array.<string>} dirtyFiles Dirty files, expressed relative to inputDir
  * @param {EventEmitter} emitter
+ * @return {Promise}
  * @private
  */
-SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, emitter) {
+SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, outputDir, allFiles, dirtyFiles, emitter) {
+  var self = this
+  return this._compileTemplateFilesAsync(inputDir, outputDir, allFiles, dirtyFiles)
+    .then(function () {
+      self._finalizeCompileTemplates(outputDir, emitter)
+    }, function (err) {
+      emitter.emit('compile', err, false)
+    })
+}
+
+
+/**
+ * Compiles all soy files, returning a promise.
+ * @see compileTemplates for the emitter API.
+ * @param {string} inputDir Input directory from where the compiler spawns.
+ * @param {string} outputDir
+ * @param {Array.<string>} allFiles All files, expressed relative to inputDir
+ * @param {Array.<string>} dirtyFiles Dirty files, expressed relative to inputDir
+ * @return {Promise}
+ * @private
+ */
+SoyCompiler.prototype._compileTemplateFilesAsync = function (inputDir, outputDir, allFiles, dirtyFiles) {
   var options = this._options
-  var outputDir = this._getOutputDir()
-  var outputPathFormat = outputDir + '/{INPUT_DIRECTORY}{INPUT_FILE_NAME}.js'
+  var outputPathFormat = path.join(outputDir, '{INPUT_DIRECTORY}', '{INPUT_FILE_NAME}.js')
 
-  if (files.length == 0) return emitter.emit('compile', null, true)
-
-  if (options.allowDynamicRecompile) {
-    // Set up a watch for changes to files.  Currently this will recompile all templates when
-    // ever one changes. TODO(dan): Make this compile individual files.
-    var filePaths = files.map(function (file) { return path.resolve(inputDir, file) })
-    this._watchFiles(filePaths, this._compileTemplateFilesAndEmit.bind(this, inputDir, files, emitter))
-  }
+  if (dirtyFiles.length == 0) return Q.resolve(true)
 
   // Arguments for running the soy compiler via java.
   var args = [
@@ -232,7 +251,7 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
     args.push('--locales', options.locales.join(','))
 
     if (options.locales.length > 1) {
-      outputPathFormat = outputDir + '/{INPUT_DIRECTORY}{INPUT_FILE_NAME_NO_EXT}_{LOCALE}.soy.js'
+      outputPathFormat = path.join(outputDir, '{LOCALE}', '{INPUT_DIRECTORY}', '{INPUT_FILE_NAME}.js')
     }
   }
 
@@ -251,7 +270,7 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
   args.push('--outputPathFormat', outputPathFormat)
 
   // List of files
-  args = args.concat(files)
+  args = args.concat(dirtyFiles)
 
   // Execute the command inside the input directory.
   var cp = child_process.spawn('java', args, {cwd: inputDir})
@@ -263,6 +282,7 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
 
   var terminated = false
   var self = this
+  var deferred = Q.defer()
 
   function onExit(exitCode) {
     if (terminated) return
@@ -271,25 +291,9 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
       // Log all the errors and execute the callback with a generic error object.
       terminated = true
       console.error('soynode: Compile error\n', stderr)
-      emitter.emit('compile', new Error('Error compiling templates'), false)
+      deferred.reject(new Error('Error compiling templates'))
     } else {
-
-      var vmTypes = [DEFAULT_VM_CONTEXT]
-      if (options.locales && options.locales.length > 0) {
-        vmTypes = options.locales.concat()
-      }
-
-      var next = function () {
-        if (vmTypes.length === 0) {
-          self._finalizeCompileTemplates(outputDir, emitter)
-        } else {
-          self._postCompileProcess(outputDir, files, vmTypes.pop(), function(err) {
-            if (err) return emitter.emit('compile', err, false)
-            next()
-          })
-        }
-      }
-      next()
+      deferred.resolve(true)
     }
   }
 
@@ -299,6 +303,25 @@ SoyCompiler.prototype._compileTemplateFilesAndEmit = function (inputDir, files, 
   })
 
   cp.on('exit', onExit)
+
+  return deferred.promise.then(function () {
+    var vmTypes = [DEFAULT_VM_CONTEXT]
+    if (options.locales && options.locales.length > 0) {
+      vmTypes = options.locales.concat() // clone
+    }
+
+    var next = function () {
+      if (vmTypes.length === 0) {
+        return Q.resolve(true)
+      } else {
+        return self._postCompileProcess(outputDir, allFiles, vmTypes.pop()).then(next)
+      }
+    }
+    return next().fail(function (err) {
+      console.error('Error post-processing templates', err)
+      throw err
+    })
+  })
 }
 
 
@@ -316,7 +339,9 @@ SoyCompiler.prototype._compileTemplatesAndEmit = function (inputDir, emitter) {
     if (err) return emitter.emit('compile', err, false)
     if (files.length == 0) return emitter.emit('compile', null, true)
 
-    self._compileTemplateFilesAndEmit(inputDir, files, emitter)
+    var outputDir = self._createOutputDir()
+    self._maybeSetupDynamicRecompile(inputDir, outputDir, files, emitter)
+    self._compileTemplateFilesAndEmit(inputDir, outputDir, files, files, emitter)
   })
 }
 
@@ -329,7 +354,7 @@ SoyCompiler.prototype._compileTemplatesAndEmit = function (inputDir, emitter) {
 SoyCompiler.prototype._finalizeCompileTemplates = function (outputDir, emitter) {
   emitter.emit('compile', null, true)
 
-  if (this._options.eraseTemporaryFiles) {
+  if (this._options.eraseTemporaryFiles && !this._options.allowDynamicRecompile) {
     exec('rm -r \'' + outputDir + '\'', {}, function (err) {
       // TODO(dan): This is a pretty nasty way to delete the files.  Maybe use rimraf
       if (err) console.error('soynode: Error deleting temporary files', err)
@@ -348,7 +373,9 @@ SoyCompiler.prototype.loadCompiledTemplates = function(inputDir, callback) {
   var self = this
   findFiles(inputDir, 'soy.js', function (err, files) {
     if (err) return callback(err, false)
-    files = files.map(function (file) { return path.join(inputDir, file) })
+    files = files.map(function (file) {
+      return path.join(inputDir, file)
+    })
     self.loadCompiledTemplateFiles(files, callback)
   })
 }
@@ -375,24 +402,49 @@ SoyCompiler.prototype.loadCompiledTemplateFiles = function (files, callbackOrOpt
 
 /**
  * Adds a file system watch to the provided files, and executes the fn when changes are detected.
- * @param {Array.<string>} files
- * @param {Function} fn
+ * @param {string} inputDir
+ * @param {string} outputDir
+ * @param {Array.<string>} relativeFilePaths
+ * @param {EventEmitter} emitter
  * @private
  */
-SoyCompiler.prototype._watchFiles = function (files, fn) {
-  files.forEach(function (file) {
-    if (this._watches[file]) return
+SoyCompiler.prototype._maybeSetupDynamicRecompile = function (inputDir, outputDir, relativeFilePaths, emitter) {
+  if (!this._options.allowDynamicRecompile) {
+    return
+  }
+
+  var currentCompilePromise = Q.resolve(true)
+  var dirtyFileSet = {}
+  var self = this
+  relativeFilePaths.forEach(function (relativeFile) {
+    var file = path.resolve(inputDir, relativeFile)
+    if (self._watches[file]) return
     try {
-      this._watches[file] = Date.now()
+      self._watches[file] = Date.now()
 
       fs.watchFile(file, {}, function () {
         var now = Date.now()
         // Ignore spurious change events.
-        if (now - this._watches[file] < 1000) return
-        console.log('soynode: Recompiling templates due to change in [%s]', file)
-        this._watches[file] = now
-        fn.call(this)
-      }.bind(this))
+        if (now - self._watches[file] < 1000) return Q.resolve(true)
+
+        dirtyFileSet[relativeFile] = true
+        self._watches[file] = now
+
+        // Wait until the previous compile has completed before starting a new one.
+        currentCompilePromise = currentCompilePromise.then(function () {
+          var dirtyFiles = Object.keys(dirtyFileSet)
+          if (!dirtyFiles.length) {
+            // Nothing needs to be recompiled because it was already caught by another job.
+            return
+          }
+          dirtyFileSet = {}
+          console.log('soynode: Recompiling templates due to change in [%s]', dirtyFiles)
+          return self._compileTemplateFilesAndEmit(inputDir, outputDir, relativeFilePaths, dirtyFiles, emitter)
+        })
+
+        // Return the promise, for use when testing. fs.watchFile will just ignore this.
+        return currentCompilePromise
+      })
     } catch (e) {
       console.warn('soynode: Error watching ' + file, e)
     }
@@ -429,20 +481,20 @@ SoyCompiler.prototype._concatOutput = function (outputDir, files, vmType) {
  * @param {string} outputDir
  * @param {Array.<string>} files
  * @param {string=} vmType optional type of the vm
- * @param {function (Error, boolean)} callback
+ * @return {Promise}
  * @private
  */
-SoyCompiler.prototype._postCompileProcess = function (outputDir, files, vmType, callback) {
+SoyCompiler.prototype._postCompileProcess = function (outputDir, files, vmType) {
   var options = this._options
   vmType = vmType || DEFAULT_VM_CONTEXT
 
   // Build a list of paths that we expect as output of the soy compiler.
   var currentPath
   var templatePaths = files.map(function (file) {
-    currentPath = path.join(outputDir , file) + '.js'
-
     if (options.locales && options.locales.length > 1) {
-      currentPath = currentPath.replace(/.soy.js/, '_' + vmType + '.soy.js')
+      currentPath = path.join(outputDir, vmType, file) + '.js'
+    } else {
+      currentPath = path.join(outputDir, file) + '.js'
     }
 
     return currentPath
@@ -456,9 +508,9 @@ SoyCompiler.prototype._postCompileProcess = function (outputDir, files, vmType, 
 
   if (options.loadCompiledTemplates) {
     // Load the compiled templates into memory.
-    this.loadCompiledTemplateFiles(templatePaths, {vmType: vmType}, callback)
+    return Q.nfcall(this.loadCompiledTemplateFiles.bind(this, templatePaths, {vmType: vmType}))
   } else {
-    callback()
+    return Q.resolve(true)
   }
 }
 


### PR DESCRIPTION
Hello @kylehg, @ikai, 

Please review the following commits I made in branch 'nicks/lazy'.

5234010c48729ba570bd0aab92f6fc5329526193 (2016-12-01 14:06:09 -0500)
Only recompile soy templates that have changed, which should make soy recompilation much more responsive.

Also, adjust directory structure from path/to/file_locale.soy.js to locale/path/to/file.soy.js,
which is easier to build deps for.

R=@kylehg
R=@ikai